### PR TITLE
for handling a litle strange descriptor.

### DIFF
--- a/src/Plugins/Hosts/GadgetFS_helpers.c
+++ b/src/Plugins/Hosts/GadgetFS_helpers.c
@@ -39,6 +39,8 @@
 #include <mntent.h>
 #include "TRACE.h"
 
+#include "myDebug.h"
+
 static char *gadgetfs_path;
 
 void clean_tmp() {
@@ -65,13 +67,13 @@ void clean_tmp() {
 		if (readdir_r(dir, entry, &result) < 0) break;
 		if (!result) {break;}
 		if (strlen(entry->d_name)==13 && strncmp(entry->d_name,"gadget-",7)==0) {
-	    	rmCount++;
-	    	if (rmDirs) {
-	    		rmDirs=realloc(rmDirs,sizeof(char*)*rmCount);
-	    	} else {
-	    		rmDirs=malloc(sizeof(char*));
-	    	}
-	    	rmDirs[rmCount-1]=strdup(entry->d_name);
+			rmCount++;
+			if (rmDirs) {
+				rmDirs=realloc(rmDirs,sizeof(char*)*rmCount);
+			} else {
+				rmDirs=malloc(sizeof(char*));
+			}
+			rmDirs[rmCount-1]=strdup(entry->d_name);
 		}
 	}
 	free(entry);
@@ -218,9 +220,12 @@ int open_gadget() {
 	}
 	
 	char path[256];
+	int ret, status;
 	sprintf(path, "%s/%s", gadgetfs_path, filename);
 	
-	return open(path, O_CLOEXEC | O_RDWR);
+	ret = open(path, O_CLOEXEC | O_RDWR);
+	
+	return ret;
 }
 
 int open_endpoint(__u8 epAddress) {

--- a/src/Plugins/Hosts/HostProxy_GadgetFS.cpp
+++ b/src/Plugins/Hosts/HostProxy_GadgetFS.cpp
@@ -39,6 +39,8 @@
 #include "Interface.h"
 #include "Endpoint.h"
 
+#include "myDebug.h"
+
 int HostProxy_GadgetFS::debugLevel=0;
 
 HostProxy_GadgetFS::HostProxy_GadgetFS(ConfigParser *cfg) {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -52,6 +52,7 @@ set(c_sources
 	${CMAKE_CURRENT_SOURCE_DIR}/get_tid.c
 	${CMAKE_CURRENT_SOURCE_DIR}/HaltSignal.c
 	${CMAKE_CURRENT_SOURCE_DIR}/mqueue_helpers.c
+	${CMAKE_CURRENT_SOURCE_DIR}/myDebug.c
 	CACHE INTERNAL "List of C sources")
 
 set(headers
@@ -77,6 +78,7 @@ set(headers
 	${CMAKE_CURRENT_SOURCE_DIR}/Packet.h
 	${CMAKE_CURRENT_SOURCE_DIR}/Proxy.h
 	${CMAKE_CURRENT_SOURCE_DIR}/USBString.h
+	${CMAKE_CURRENT_SOURCE_DIR}/myDebug.h
 	CACHE INTERNAL "List of headers")
 
 add_definitions( -DPLUGIN_PATH="${CMAKE_INSTALL_PREFIX}/lib/USBProxy/")

--- a/src/lib/Configuration.cpp
+++ b/src/lib/Configuration.cpp
@@ -40,6 +40,8 @@
 #include "DeviceProxy.h"
 #include "USBString.h"
 
+#include "myDebug.h"
+
 Configuration::Configuration(Device* _device,DeviceProxy* proxy, int idx,bool otherSpeed)
 {
 	device=_device;
@@ -124,7 +126,10 @@ size_t Configuration::get_full_descriptor_length() {
 	size_t total=descriptor.bLength;
 	int i;
 	for(i=0;i<descriptor.bNumInterfaces;i++) {
-		total+=interfaceGroups[i]->get_full_descriptor_length();
+		// modified 20140903 atsumi@aizulab.com
+		if ( interfaceGroups[i]) {
+			total+=interfaceGroups[i]->get_full_descriptor_length();
+		}
 	}
 	return total;
 }
@@ -136,7 +141,10 @@ __u8* Configuration::get_full_descriptor() {
 	p=p+descriptor.bLength;
 	int i;
 	for(i=0;i<descriptor.bNumInterfaces;i++) {
-		interfaceGroups[i]->get_full_descriptor(&p);
+		// modified 20140903 atsumi@aizulab.com
+		if ( interfaceGroups[i]) {
+			interfaceGroups[i]->get_full_descriptor(&p);
+		}
 	}
 	return buf;
 }

--- a/src/lib/DeviceQualifier.cpp
+++ b/src/lib/DeviceQualifier.cpp
@@ -38,6 +38,8 @@
 
 #include "DeviceProxy.h"
 
+#include "myDebug.h"
+
 DeviceQualifier::DeviceQualifier(Device* _device,DeviceProxy* proxy) {
 	device=_device;
 
@@ -64,8 +66,18 @@ DeviceQualifier::DeviceQualifier(Device* _device,DeviceProxy* proxy) {
 		for (j=0;j<configurations[i]->get_descriptor()->bNumInterfaces;j++) {
 			int k;
 			for (k=0;k<configurations[i]->get_interface_alernate_count(j);k++) {
-				__u8 iInterface=configurations[i]->get_interface_alternate(j,k)->get_descriptor()->iInterface;
-				if (iInterface) {device->add_string(iInterface);}
+
+				// modified 20140903 atsumi@aizulab.com
+				// begin
+				if ( configurations[i]->get_interface_alternate(j,k)) {
+					if ( configurations[i]->get_interface_alternate(j,k)->get_descriptor()) {
+						__u8 iInterface=configurations[i]->get_interface_alternate(j,k)->get_descriptor()->iInterface;
+						if (iInterface) {
+							device->add_string(iInterface);
+						}
+					}
+				}
+				// End
 			}
 		}
 	}

--- a/src/lib/InterfaceGroup.cpp
+++ b/src/lib/InterfaceGroup.cpp
@@ -35,6 +35,7 @@
 #include "Device.h"
 #include "Interface.h"
 
+#include "myDebug.h"
 
 InterfaceGroup::InterfaceGroup(__u8 _number) {
 	number=_number;
@@ -59,13 +60,24 @@ InterfaceGroup::~InterfaceGroup() {
 size_t InterfaceGroup::get_full_descriptor_length() {
 	size_t total=0;
 	int i;
-	for(i=0;i<alternateCount;i++) {total+=interfaces[i]->get_full_descriptor_length();}
+	for(i=0;i<alternateCount;i++) {
+		// modified 20140903 atsumi@aizulab.com
+		if ( interfaces[i]) {
+			total+=interfaces[i]->get_full_descriptor_length();
+		}
+	}
 	return total;
 }
 
 void InterfaceGroup::get_full_descriptor(__u8** p) {
 	int i;
-	for(i=0;i<alternateCount;i++) {interfaces[i]->get_full_descriptor(p);}
+	
+	for(i=0;i<alternateCount;i++) {
+		// modified 20140903 atsumi@aizulab.com
+		if ( interfaces[i]) {
+			interfaces[i]->get_full_descriptor(p);
+		}
+	}
 }
 
 void InterfaceGroup::add_interface(Interface* interface) {
@@ -94,7 +106,10 @@ void InterfaceGroup::print(__u8 tabs) {
 	int i;
 	printf("%.*sInterface(%d):\n",tabs,TABPADDING,number);
 	for(i=0;i<alternateCount;i++) {
-		interfaces[i]->print(tabs+1,i==activeAlternateIndex?true:false);
+		// modified 20140903 atsumi@aizulab.com
+		if ( interfaces[i]) {
+			interfaces[i]->print(tabs+1,i==activeAlternateIndex?true:false);
+		}
 	}
 }
 

--- a/src/lib/Manager.cpp
+++ b/src/lib/Manager.cpp
@@ -47,6 +47,8 @@
 #include "RelayWriter.h"
 #include "Injector.h"
 
+#include "myDebug.h"
+
 Manager::Manager() {
 	haltSignal=0;
 	status=USBM_IDLE;
@@ -336,7 +338,11 @@ void Manager::start_control_relaying(){
 		spinner(1);
 		rc=hostProxy->connect(device);
 	}
-	if (rc!=0) {status=USBM_SETUP_ABORT;stop_relaying();return;}
+	if (rc!=0) {
+		status=USBM_SETUP_ABORT;
+		stop_relaying();
+		return;
+	}
 
 	if (out_readers[0]) {
 		out_readers[0]->set_haltsignal(haltSignal);

--- a/src/lib/myDebug.c
+++ b/src/lib/myDebug.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include "myDebug.h"
+
+void myDump( void *p, int len)
+{
+  int i;
+  for ( i = 0; i < len; i++) {
+    printf( "%02x ", *(char *)(p + i));
+    if ( i % 16 == 15) putchar( '\n');
+  }
+  if ( i % 16 != 15) putchar( '\n');
+  putchar( '\n');
+}

--- a/src/lib/myDebug.h
+++ b/src/lib/myDebug.h
@@ -1,0 +1,21 @@
+#ifndef _MYDEBUG_H
+#define _MYDEBUG_H 1
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void myDump( void*, int);
+
+#ifdef __cplusplus
+}
+#endif
+
+#define dbgMessage(str) fprintf( stderr, "%s %s() %d %s\n", __FILE__, __func__, __LINE__, str)
+
+#define IS_FAILED(expr) (((expr)) ? false : ( fprintf( stderr, "%s: %d %s: `%s' failed.\n", __FILE__, __LINE__, __func__, __STRING(expr)), true))
+
+#endif // _MYDEBUG_H

--- a/src/tools/usb-mitm.cpp
+++ b/src/tools/usb-mitm.cpp
@@ -43,6 +43,7 @@
 #include "TRACE.h"
 #include "Manager.h"
 #include "ConfigParser.h"
+#include "myDebug.h"
 
 static int debug=0;
 
@@ -104,7 +105,7 @@ extern "C" int main(int argc, char **argv)
 	bool client=false, server=false, device_set=false, host_set=false;
 	fprintf(stderr,"SIGRTMIN: %d\n",SIGRTMIN);
 
-	//int vendorId=LIBUSB_HOTPLUG_MATCH_ANY, productId=LIBUSB_HOTPLUG_MATCH_ANY;
+	// int vendorId=LIBUSB_HOTPLUG_MATCH_ANY, productId=LIBUSB_HOTPLUG_MATCH_ANY;
 	
 	struct sigaction action;
 	memset(&action, 0, sizeof(struct sigaction));
@@ -198,7 +199,6 @@ extern "C" int main(int argc, char **argv)
 	cfg->print_config();
 
 	manager->start_control_relaying();
-
 	while (manager->get_status()==USBM_RELAYING) {usleep(10000);}
 
 	// Tidy up


### PR DESCRIPTION
Hi,

I'm modifying USBProxy for some software on Android smartphone.
The smartphone behaves like an network interface in that time, and it tell USBProxy a little strange descriptor as follows.

Then, I have 2 problems. 

At the first, in Device::add_string(), USBProxy frees allocated memory twice or more sometimes because it assigned a same String Descriptor to 2 or more elements of strings[][] array. Therefore delete(strings[index][i]) was commented out.It means I have another problem for leaking memory.

At the second, some descriptors don't have a consecutive number. For example, the first Interface descriptor has the zeroth and the second alternate interface descriptors. Therefore the first alternate interface descriptor becomes NULL, but USBProxy causes 'segmentation fault' when it calculates the length of descriptors for example. Then I modified them to avoid NULL descriptor.

I don't know whether there is this along your intention. I will send you 'pull request'. I'd like you review it.

root@arm:~/Projects/USBProxy/build# tools/usb-mitm -dd -l
SIGRTMIN: 34
CP: Vector Plugins
CP: Pointer PacketFilter_StreamLog::file
CP: String DeviceProxy = DeviceProxy_LibUSB
CP: String HostProxy = HostProxy_GadgetFS
Loading plugins from /usr/local/lib/USBProxy/
vendorId=ffffffff
productId=ffffffff
cleaning up /tmp
removing 1
Made directory /tmp/gadget-6Aepe2 for gadget
Printing Config data
    Strings: 2
        DeviceProxy: DeviceProxy_LibUSB
        HostProxy: HostProxy_GadgetFS
    Vectors: 1
        Plugins:
            PacketFilter_StreamLog
Pointer: 1
        PacketFilter_StreamLog::file: 0xb6d77540
Made directory /tmp/mqueue-gd1BOY for mqueue
cleaning up /tmp/mqueue-gd1BOY
removing 2
Device: 12 01 00 02 02 00 00 40 e8 04 5d 68 28 02 02 03 04 01
  Manufacturer: SAMSUNG
  Product:      SAMSUNG_Android_SC-06D
  Serial:       d0120973
    *Config(1): 09 02 5e 00 02 01 00 c0 30
        Interface(0):
            *Alt(0): 09 04 00 00 01 02 0d 00 05
               Name: CDC Network Control Model (NCM)
            Other(24): 05 24 00 10 01
            Other(24): 05 24 06 00 01
            Other(24): 0d 24 0f 07 00 00 00 00 ea 05 00 00 00
            Other(24): 06 24 1a 00 01 11
                EP(82): 07 05 82 03 10 00 09
             Alt(2): 08 0b 00 02 02 0d 00 08 08
               Name: CDC NCM
        Interface(1):
            *Alt(0): 09 04 01 00 00 0a 00 01 06
               Name: CDC Network Data
             Alt(1): 09 04 01 01 02 0a 00 01 06
               Name: CDC Network Data
                EP(81): 07 05 81 02 00 02 00
                EP(01): 07 05 01 02 00 02 00
HS Qualifier: 0a 06 00 02 02 00 00 40 01 00
     Config(1): 09 07 5e 00 02 01 00 c0 30
        Interface(0):
            *Alt(0): 09 04 00 00 01 02 0d 00 05
               Name: CDC Network Control Model (NCM)
            Other(24): 05 24 00 10 01
            Other(24): 05 24 06 00 01
            Other(24): 0d 24 0f 07 00 00 00 00 ea 05 00 00 00
            Other(24): 06 24 1a 00 01 11
                EP(82): 07 05 82 03 10 00 20
             Alt(2): 08 0b 00 02 02 0d 00 08 08
               Name: CDC NCM
        Interface(1):
            *Alt(0): 09 04 01 00 00 0a 00 01 06
               Name: CDC Network Data
             Alt(1): 09 04 01 01 02 0a 00 01 06
               Name: CDC Network Data
                EP(81): 07 05 81 02 40 00 00
                EP(01): 07 05 01 02 40 00 00
## 

Kiyotaka Atsumi
atsumi@aizulab.com, kiyotaka@ka-lab.jp
