### PR TITLE
Fixed relaytest compile by adding -lrt

### DIFF
--- a/test/relaytest/Makefile
+++ b/test/relaytest/Makefile
@@ -40,7 +40,7 @@ else
 endif
 
 LDFLAGS += -Wl,--gc-sections
-LDFLAGS += -l$(LIBUSB) -ludev -lstdc++ -lboost_atomic -lpthread
+LDFLAGS += -l$(LIBUSB) -ludev -lstdc++ -lboost_atomic -lpthread -lrt
 
 C_FILES := $(wildcard *.c)
 CPP_FILES := $(wildcard *.cpp)


### PR DESCRIPTION
Added library rt to LDFLAGS for relay test to allow it to compile on my machine (Archlinux, up-to-date gcc e.a.).
This is my first every merge request on github, let's see if I did correctly. Thanks.
