### PR TITLE
Add Support for A10/A20 devices

### DIFF
--- a/src/Plugins/Hosts/GadgetFS_helpers.h
+++ b/src/Plugins/Hosts/GadgetFS_helpers.h
@@ -38,11 +38,14 @@ extern "C" {
  */
 #define	USB_BUFSIZE	(7 * 1024)
 
-/* Find & open the appropriate gadget file on the GadgetFS filesystem */
-int open_gadget();
+/* open the appropriate gadget file on the GadgetFS filesystem */
+int open_gadget(const char *);
+
+/* Find the appropriate gadget file on the GadgetFS filesystem */
+const char * find_gadget_filename();
 
 /* Find & open an endpoint file */
-int open_endpoint(__u8 epAddress);
+int open_endpoint(__u8 epAddress, const char * gadget_filename);
 
 /* Mount gadgetfs filesystem in a temporary directory */
 int mount_gadget();

--- a/src/Plugins/Hosts/HostProxy_GadgetFS.cpp
+++ b/src/Plugins/Hosts/HostProxy_GadgetFS.cpp
@@ -134,7 +134,8 @@ int HostProxy_GadgetFS::connect(Device* device,int timeout) {
 		free(hex);
 	}
 
-	p_device_file = open_gadget();
+	device_filename = find_gadget_filename();
+	p_device_file = open_gadget(device_filename);
 	if (p_device_file < 0) {
 		fprintf(stderr,"Fail on open %d %s\n",errno,strerror(errno));
 		return 1;
@@ -164,7 +165,8 @@ int HostProxy_GadgetFS::reconnect() {
 		free(hex);
 	}
 
-	p_device_file = open_gadget();
+	device_filename = find_gadget_filename();
+	p_device_file = open_gadget(device_filename);
 	if (p_device_file < 0) {
 		fprintf(stderr,"Fail on open %d %s\n",errno,strerror(errno));
 		return 1;
@@ -478,7 +480,7 @@ void HostProxy_GadgetFS::setConfig(Configuration* fs_cfg,Configuration* hs_cfg,b
 
 				__u8 epAddress=fs_ep->bEndpointAddress;
 
-				int fd=open_endpoint(epAddress);
+				int fd=open_endpoint(epAddress, device_filename);
 				if (fd<0) {
 					fprintf(stderr,"Fail on open EP%02x %d %s\n",epAddress,errno,strerror(errno));
 					return;

--- a/src/Plugins/Hosts/HostProxy_GadgetFS.h
+++ b/src/Plugins/Hosts/HostProxy_GadgetFS.h
@@ -20,6 +20,7 @@ class HostProxy_GadgetFS: public HostProxy {
 private:
 	bool p_is_connected;
 	int p_device_file;
+	const char* device_filename;
 	struct aiocb* p_epin_async[16];
 	struct aiocb* p_epout_async[16];
 	bool p_epin_active[16];


### PR DESCRIPTION
This pull request adds support for Allwinner A10/A20 based devices like Olimex lime, Cubieboard and Banana Pi.

Sunxi kernel 3.4 is required as there is no support for gadgetfs in the mainline kernel yet.

I tested it on a cubieboard A10. 
