### PR TITLE
Fix stack smashing errors

### DIFF
--- a/src/lib/Manager.cpp
+++ b/src/lib/Manager.cpp
@@ -378,7 +378,7 @@ void Manager::start_data_relaying() {
 
 	int i,j;
 	for (i=1;i<16;i++) {
-		char mqname[16];
+		char mqname[22];
 		struct mq_attr mqa;
 		mqa.mq_maxmsg=1;
 		mqa.mq_msgsize=4;

--- a/src/lib/mqueue_helpers.c
+++ b/src/lib/mqueue_helpers.c
@@ -112,7 +112,7 @@ int clean_mqueue() {
 
 	fprintf(stderr,"removing %d\n",rmCount);
 	for (i=0;i<rmCount;i++) {
-		char buf[20]={0x0};
+		char buf[22]={0x0};
 		strcat(buf,"/");
 		strcat(buf,rmQueues[i]);
 		mq_unlink(buf);


### PR DESCRIPTION
I increased the char size to 22 but I think this still is not quiet right. The char contains a string that includes a PID and I believe it could get bigger than five digits.

Here is an example string: /USBProxy(15234)-81-EP
