### PR TITLE
Typo in PcapLogger: Filename needs to be uppercase as in usb-mitm

### DIFF
--- a/src/Plugins/Filters/PacketFilter_PcapLogger.cpp
+++ b/src/Plugins/Filters/PacketFilter_PcapLogger.cpp
@@ -15,7 +15,7 @@
 
 
 PacketFilter_PcapLogger::PacketFilter_PcapLogger(ConfigParser *cfg) {
-	std::string filename = cfg->get("PacketFilter_PcapLogger::filename");
+	std::string filename = cfg->get("PacketFilter_PcapLogger::Filename");
 	pkt_count = 0;
 	file = fopen(filename.c_str(), "w");
 	pcap_file = pcap_open_dead(DLT_USB_LINUX, SNAP_LEN);


### PR DESCRIPTION
Another small pull request from me:-)

Cheers
Sören
