### PR TITLE
Fix tcp hostproxy

### DIFF
--- a/src/Plugins/Hosts/HostProxy_TCP.h
+++ b/src/Plugins/Hosts/HostProxy_TCP.h
@@ -14,7 +14,6 @@ private:
 	TCP_Helper* network;
 
 public:
-	static int debugLevel;
 	HostProxy_TCP(const char* address=NULL);
 	HostProxy_TCP(ConfigParser *cfg);
 	virtual ~HostProxy_TCP();

--- a/src/lib/PluginManager.cpp
+++ b/src/lib/PluginManager.cpp
@@ -20,7 +20,7 @@ void *PluginManager::load_shared_lib(std::string plugin_name) {
 	std::string plugin_file = PLUGIN_PATH + plugin_name + ".so";
 	void* plugin_lib = dlopen(plugin_file.c_str(), RTLD_LAZY);
 	if(!plugin_lib)
-		fprintf(stderr, "error opening library %s\n", plugin_file.c_str());
+		fprintf(stderr, "error opening library %s\n",  dlerror());
 	
 	return plugin_lib;
 }

--- a/src/lib/TCP_Helper.cpp
+++ b/src/lib/TCP_Helper.cpp
@@ -329,7 +329,8 @@ bool TCP_Helper::is_connected() {
 void TCP_Helper::send_data(int ep,__u8* data,int length) {
 	int port=(ep&0x80)?(ep&0xf)|0x10:ep;
 	write(ep_socket[port],data,length);
-	fprintf(stderr,"Wrote %d bytes to FD %d\n",length,ep_socket[port]);
+	if(debugLevel)
+		fprintf(stderr,"Wrote %d bytes to FD %d\n",length,ep_socket[port]);
 }
 
 void TCP_Helper::receive_data(int ep,__u8** data,int *length,int timeout) {
@@ -341,7 +342,8 @@ void TCP_Helper::receive_data(int ep,__u8** data,int *length,int timeout) {
 		*data=(__u8*)malloc(TCP_BUFFER_SIZE);
 		*length=read(ep_socket[port],*data,TCP_BUFFER_SIZE);
 		*data=(__u8*)realloc(*data,*length);
-		if (*length) fprintf(stderr,"Read %d bytes from FD %d\n",*length,ep_socket[port]);
+		if(debugLevel)
+			if (*length) fprintf(stderr,"Read %d bytes from FD %d\n",*length,ep_socket[port]);
 	}
 }
 


### PR DESCRIPTION
When running usb-mitm with -c I was getting a non-descript "error opening library /usr/local/lib/USBProxy/HostProxy_TCP.so".

I've added dlerror() to elucidate the cause of the failure in load in such cases and resolved the cause of the failure in this case.

I also tacked-on silencing the "Wrote XX bytes" and "Read XX bytes" messages printed by the server and client