### PR TITLE
USB Mass Storages fix with LibUSB

### DIFF
--- a/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
+++ b/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
@@ -399,6 +399,7 @@ void DeviceProxy_LibUSB::send_data(uint8_t endpoint, uint8_t attributes, uint16_
 	}
 
 	int transferred;
+	int attempt = 0;
 	int rc = LIBUSB_SUCCESS;
 
 	switch (attributes & USB_ENDPOINT_XFERTYPE_MASK) {

--- a/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
+++ b/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
@@ -445,7 +445,7 @@ void DeviceProxy_LibUSB::receive_data(uint8_t endpoint, uint8_t attributes, uint
 	//if (timeout < 10)
 		//timeout = 10;	//TODO: explain this!
 
-	/* Skazza 20-10-2016
+	/* 
 	 * Infinite timeout to avoid stalling with mass storages, temporarily assigned here.
 	 * Need to check if this is useful or only do-while is needed. But for now it works.
 	 */
@@ -462,7 +462,6 @@ void DeviceProxy_LibUSB::receive_data(uint8_t endpoint, uint8_t attributes, uint
 		break;
 	case USB_ENDPOINT_XFER_BULK:
 		*dataptr = (uint8_t *) malloc(maxPacketSize * 8);
-		/* Edited by Skazza 20-10-2016 */
 		do {
 			rc = libusb_bulk_transfer(dev_handle, endpoint, *dataptr, maxPacketSize, length, timeout);
 			if (rc == LIBUSB_SUCCESS && debugLevel > 2)

--- a/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
+++ b/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
@@ -470,7 +470,7 @@ void DeviceProxy_LibUSB::receive_data(uint8_t endpoint, uint8_t attributes, uint
 			if ((rc == LIBUSB_ERROR_PIPE || rc == LIBUSB_ERROR_TIMEOUT))
 				libusb_clear_halt(dev_handle, endpoint);
 			
-			attempts++;
+			attempt++;
 		} while ((rc == LIBUSB_ERROR_PIPE || rc == LIBUSB_ERROR_TIMEOUT) && attempt < MAX_ATTEMPTS);
 	case USB_ENDPOINT_XFER_INT:
 		*dataptr = (uint8_t *) malloc(maxPacketSize);


### PR DESCRIPTION
Change receive_data in DeviceProxy_LibUSB.cpp to fix problems with USB Mass Storages.

I've read everywhere that everyone has problems with USB Mass Storages not being recognized. 
The cause is that after device setup, the host sends an INQUIRY request (0x12) to get device information ([here](http://www.usb.org/developers/docs/devclass_docs/usbmass-ufi10.pdf), page 19). The device takes a while before responding and starting to send packets to the host, meanwhile libUSB timeout triggers and the operation fails. 

I don't know if what I said before is correct, I'm really newbie with USB Standard and I've only sniffed packets trying to solve the problem; but the working solution (tested with various USB Mass Storages with various file systems) is to add a simple do-while that waits the response from the mass storage and if the device is in STALL, the **libusb_clear_halt** will clear it. 

We make 5 attempts and then break the loop because the problem is another, and not the INQUIRY command, so we avoid infinite loops.

The timeout = 0 is needed because in my tests, sometimes the device goes in timeout while reading/writing blocks, but it needs further testing (it's working for me so I've left it there).

I don't know if the same stuff is needed in send_data also, as I said it's working for me so if you want to add it just do it.
