### PR TITLE
 Fix unintended fallthrough in receive_data

### DIFF
--- a/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
+++ b/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
@@ -240,7 +240,7 @@ int DeviceProxy_LibUSB::connect(int vendorId, int productId, bool includeHubs) {
 	unsigned char unused[4];
 	rc = libusb_get_string_descriptor(dev_handle, 0, 0, unused, sizeof(unused));
 	if (rc < 0) {
-		cerr << "Device unresponsive: " << libusb_strerror((libusb_error) rc);
+		cerr << "Device unresponsive: " << libusb_strerror((libusb_error) rc) << endl;
 		return rc;
 	}
 

--- a/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
+++ b/src/Plugins/Devices/DeviceProxy_LibUSB.cpp
@@ -478,6 +478,7 @@ void DeviceProxy_LibUSB::receive_data(uint8_t endpoint, uint8_t attributes, uint
 			
 			attempt++;
 		} while ((rc == LIBUSB_ERROR_PIPE || rc == LIBUSB_ERROR_TIMEOUT) && attempt < MAX_ATTEMPTS);
+		break;
 	case USB_ENDPOINT_XFER_INT:
 		*dataptr = (uint8_t *) malloc(maxPacketSize);
 		rc = libusb_interrupt_transfer(dev_handle, endpoint, *dataptr, maxPacketSize, length, timeout);


### PR DESCRIPTION
I think commit ff169f495021a145471c1d0f055130d54d4190a1 broke receiving data from bulk endpoints. With this fix I don't get any libusb errors anymore but someone should confirm this fix because I still don't manage to get my device working but that's probably due to something else...