### PR TITLE
Fix GET_STATUS control requests not being forwarded

### DIFF
--- a/src/Plugins/Hosts/HostProxy_GadgetFS.cpp
+++ b/src/Plugins/Hosts/HostProxy_GadgetFS.cpp
@@ -238,7 +238,7 @@ bool HostProxy_GadgetFS::is_connected() {
 
 #define NEVENT 5
 
-//return 0 in usb_ctrlrequest->brequest if there is no request
+//return 0 if there is no request, 1 otherwise
 int HostProxy_GadgetFS::control_request(usb_ctrlrequest *setup_packet, int *nbytes, __u8** dataptr,int timeout) {
 	struct usb_gadgetfs_event events[NEVENT];
 	int ret, nevent, i;
@@ -284,7 +284,7 @@ int HostProxy_GadgetFS::control_request(usb_ctrlrequest *setup_packet, int *nbyt
 				*dataptr=NULL;
 				*nbytes=0;
 			}
-			return 0;
+			return 1;
 			break;
 		case GADGETFS_NOP:
 			break;

--- a/src/Plugins/Hosts/HostProxy_TCP.cpp
+++ b/src/Plugins/Hosts/HostProxy_TCP.cpp
@@ -54,7 +54,7 @@ bool HostProxy_TCP::is_connected() {
 }
 
 
-//return 0 in usb_ctrlrequest->brequest if there is no request
+//return 0 in if there is no request, 1 otherwise
 int HostProxy_TCP::control_request(usb_ctrlrequest *setup_packet, int *nbytes, __u8** dataptr, int timeout) {
 	int length=0;
 	__u8* buf=NULL;
@@ -80,7 +80,7 @@ int HostProxy_TCP::control_request(usb_ctrlrequest *setup_packet, int *nbytes, _
 		fprintf(stderr, "TCP< %s\n",hex);
 		free(hex);
 	}
-	return 0;
+	return 1;
 }
 
 void HostProxy_TCP::send_data(__u8 endpoint,__u8 attributes,__u16 maxPacketSize,__u8* dataptr,int length) {

--- a/src/lib/RelayReader.cpp
+++ b/src/lib/RelayReader.cpp
@@ -67,8 +67,8 @@ void RelayReader::relay_read_setup() {
 			buf=NULL;
 			length=0;
 
-			hostProxy->control_request(&ctrl_req, &length, &buf, CTRL_REQUEST_TIMEOUT_MS);
-			if (ctrl_req.bRequest) {
+			int is_control_req = hostProxy->control_request(&ctrl_req, &length, &buf, CTRL_REQUEST_TIMEOUT_MS);
+			if (is_control_req) {
 				p = std::make_shared<SetupPacket>(ctrl_req,buf);
 			}
 			if (!p)


### PR DESCRIPTION
If bRequest = 0, the request would be ignored. As a result, all USB GET_STATUS
device requests where ignored.

Instead of using bRequest as "return value" to decide if a setup packet should
be generated or not in RelayReader, use the actual return value of the function
to make this decission.

Tested with a FTDI USB<->UART converter. Didn't test the HostProxy_TCP code but I think it's changed accordingly.